### PR TITLE
Interpolate LessUnitful module in macro expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.2.1] - unreleased
+- fix broken explicit imports of macros like `@unitfactors`
+
 ## [1.2.0] - 2025-02-08
 - Disable affine units and relative temperature scales as not maintainable with the approach in this package
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LessUnitful"
 uuid = "f29f6376-6e90-4d80-80c9-fb8ec61203d5"
 authors = ["Jürgen Fuhrmann <juergen-fuhrmann@web.de>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"

--- a/src/LessUnitful.jl
+++ b/src/LessUnitful.jl
@@ -72,14 +72,14 @@ See  [`@ph_str`](@ref)  for an alternative way to access physical constants.
 """
 macro ufac_str(x)
     quote
-        LessUnitful.unitfactor($(Unitful).@u_str($(x)))
+        $LessUnitful.unitfactor($(Unitful).@u_str($(x)))
     end
 end
 
 function _unitfactors(xs...)
     code = Expr(:block)
     for x in xs
-        push!(code.args, :(const $x = LessUnitful.unitfactor($Unitful.$x)))
+        push!(code.args, :(const $x = $LessUnitful.unitfactor($Unitful.$x)))
     end
     code
 end
@@ -87,7 +87,7 @@ end
 function _local_unitfactors(xs...)
     code = Expr(:block)
     for x in xs
-        push!(code.args, :(local $x = LessUnitful.unitfactor($Unitful.$x)))
+        push!(code.args, :(local $x = $LessUnitful.unitfactor($Unitful.$x)))
     end
     code
 end
@@ -189,7 +189,7 @@ export unitful
 function _phconstants(xs...)
     code = Expr(:block)
     for x in xs
-        push!(code.args, :(const $x = LessUnitful.unitfactor($PhysicalConstants.CODATA2018.$x)))
+        push!(code.args, :(const $x = $LessUnitful.unitfactor($PhysicalConstants.CODATA2018.$x)))
     end
     code
 end
@@ -197,7 +197,7 @@ end
 function _local_phconstants(xs...)
     code = Expr(:block)
     for x in xs
-        push!(code.args, :(local $x = LessUnitful.unitfactor($PhysicalConstants.CODATA2018.$x)))
+        push!(code.args, :(local $x = $LessUnitful.unitfactor($PhysicalConstants.CODATA2018.$x)))
     end
     code
 end
@@ -275,7 +275,7 @@ julia> ph"N_A"
 """
 macro ph_str(x)
     quote
-        LessUnitful.unitfactor(getglobal(LessUnitful.PhysicalConstants.CODATA2018,Symbol($x)))
+        $LessUnitful.unitfactor(getglobal($LessUnitful.PhysicalConstants.CODATA2018,Symbol($x)))
 #        LessUnitful.unitfactor(eval(Unitful.lookup_units($(PhysicalConstants.CODATA2018),Meta.parse($x))))
     end
 end


### PR DESCRIPTION
This fixes the simple (currently broken) demo:

```
julia> using LessUnitful: @unitfactors
julia> @unitfactors m
```

Internally, the macros expand to internal functions of `LessUnitful`, and this module is not available if an explicit import is used, as above.

Interpolating the module name in the expansion fixes the problem.